### PR TITLE
Change the run shortcut to shift+enter

### DIFF
--- a/web/src/components/controls/index.js
+++ b/web/src/components/controls/index.js
@@ -34,7 +34,7 @@ export class PlaygroundControls extends LitElement {
     ];
 
     window.addEventListener('keydown', (event) => {
-      if (event.ctrlKey && event.key.toUpperCase() === 'R') {
+      if (event.shiftKey && event.key === 'Enter') {
         this._notifyRunRequested();
       }
     });
@@ -182,10 +182,10 @@ export class PlaygroundControls extends LitElement {
                           `
                         : html`
                             <span class="tooltip"
-                              >Run ►
+                              >Run &#x25BA;
                               <span
                                 class="tooltip-text tooltip-text-position-bottom"
-                                >⌃+R</span
+                                >&#8679;+&#8629;</span
                               >
                             </span>
                           `}

--- a/web/src/components/panels/config-panel.js
+++ b/web/src/components/panels/config-panel.js
@@ -3,8 +3,9 @@
 import {html, LitElement} from 'lit-element';
 import {codePanelsStyles} from './styles';
 import {basicSetup, EditorView} from 'codemirror';
+import {Prec} from '@codemirror/state';
 import {keymap} from '@codemirror/view';
-import {indentWithTab} from '@codemirror/commands';
+import {indentWithTab, insertNewlineAndIndent} from '@codemirror/commands';
 import {yaml} from '@codemirror/lang-yaml';
 import {nothing} from 'lit';
 import {repeat} from 'lit/directives/repeat.js';
@@ -132,7 +133,12 @@ export class PlaygroundConfigPanel extends LitElement {
     this._editor = new EditorView({
       extensions: [
         basicSetup,
-        keymap.of([indentWithTab]),
+        Prec.highest(
+          keymap.of([
+            indentWithTab,
+            {key: 'Enter', run: insertNewlineAndIndent, shift: () => true},
+          ])
+        ),
         EditorView.lineWrapping,
         yaml(),
         EditorView.updateListener.of((v) => {

--- a/web/src/components/panels/payload-panel.js
+++ b/web/src/components/panels/payload-panel.js
@@ -4,11 +4,12 @@ import {css, html, LitElement} from 'lit-element';
 import {codePanelsStyles} from './styles';
 import {basicSetup, EditorView} from 'codemirror';
 import {keymap} from '@codemirror/view';
-import {indentWithTab} from '@codemirror/commands';
+import {indentWithTab, insertNewlineAndIndent} from '@codemirror/commands';
 import {PAYLOAD_EXAMPLES} from '../examples';
 import {linter, lintGutter} from '@codemirror/lint';
 import {json, jsonParseLinter} from '@codemirror/lang-json';
 import {nothing} from 'lit';
+import {Prec} from '@codemirror/state';
 
 export class PlaygroundPayloadPanel extends LitElement {
   static properties = {
@@ -133,7 +134,12 @@ export class PlaygroundPayloadPanel extends LitElement {
     this._editor = new EditorView({
       extensions: [
         basicSetup,
-        keymap.of([indentWithTab]),
+        Prec.highest(
+          keymap.of([
+            indentWithTab,
+            {key: 'Enter', run: insertNewlineAndIndent, shift: () => true},
+          ])
+        ),
         linter(jsonParseLinter()),
         lintGutter(),
         EditorView.lineWrapping,


### PR DESCRIPTION
The current key bind (`CTRL+R`) is conflicting with browser's refresh shortcut. This PR changes it to be `Shift+Enter` instead. 
