### PR TITLE
Fix execution logs view to properly shows mutable field values

### DIFF
--- a/internal/executor.go
+++ b/internal/executor.go
@@ -2,10 +2,6 @@
 
 package internal
 
-import (
-	"go.uber.org/zap/zaptest/observer"
-)
-
 type Metadata struct {
 	ID      string
 	Name    string
@@ -34,7 +30,7 @@ type Executor interface {
 	// ExecuteMetricStatements is like ExecuteLogStatements, but for metrics.
 	ExecuteMetricStatements(config, input string) ([]byte, error)
 	// ObservedLogs returns the statements execution's logs
-	ObservedLogs() *observer.ObservedLogs
+	ObservedLogs() *ObservedLogs
 	// Metadata returns information about the executor
 	Metadata() Metadata
 }

--- a/internal/log_observer.go
+++ b/internal/log_observer.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"go.uber.org/zap/zapcore"
+	"sync"
+)
+
+type LoggedEntry struct {
+	entry               zapcore.Entry
+	consoleEncodedEntry string
+}
+
+func (e *LoggedEntry) ConsoleEncodedEntry() string {
+	return e.consoleEncodedEntry
+}
+
+type ObservedLogs struct {
+	mu   sync.RWMutex
+	logs []LoggedEntry
+}
+
+func (o *ObservedLogs) Len() int {
+	o.mu.RLock()
+	n := len(o.logs)
+	o.mu.RUnlock()
+	return n
+}
+
+func (o *ObservedLogs) All() []LoggedEntry {
+	o.mu.RLock()
+	ret := make([]LoggedEntry, len(o.logs))
+	copy(ret, o.logs)
+	o.mu.RUnlock()
+	return ret
+}
+
+func (o *ObservedLogs) TakeAll() []LoggedEntry {
+	o.mu.Lock()
+	ret := o.logs
+	o.logs = nil
+	o.mu.Unlock()
+	return ret
+}
+
+func (o *ObservedLogs) add(log LoggedEntry) {
+	o.mu.Lock()
+	o.logs = append(o.logs, log)
+	o.mu.Unlock()
+}
+
+func NewLogObserver(level zapcore.LevelEnabler, config zapcore.EncoderConfig) (zapcore.Core, *ObservedLogs) {
+	ol := &ObservedLogs{}
+	return &contextObserver{
+		config:       config,
+		LevelEnabler: level,
+		logs:         ol,
+	}, ol
+}
+
+type contextObserver struct {
+	zapcore.LevelEnabler
+	config  zapcore.EncoderConfig
+	logs    *ObservedLogs
+	context []zapcore.Field
+}
+
+var _ zapcore.Core = (*contextObserver)(nil)
+
+func (co *contextObserver) Level() zapcore.Level {
+	return zapcore.LevelOf(co.LevelEnabler)
+}
+
+func (co *contextObserver) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if co.Enabled(ent.Level) {
+		return ce.AddCore(ent, co)
+	}
+	return ce
+}
+
+func (co *contextObserver) With(fields []zapcore.Field) zapcore.Core {
+	return &contextObserver{
+		LevelEnabler: co.LevelEnabler,
+		logs:         co.logs,
+		context:      append(co.context[:len(co.context):len(co.context)], fields...),
+	}
+}
+
+func (co *contextObserver) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	encoder := zapcore.NewConsoleEncoder(co.config)
+	encodedEntryBuffer, err := encoder.EncodeEntry(entry, fields)
+	if err != nil {
+		return err
+	}
+
+	co.logs.add(LoggedEntry{entry, encodedEntryBuffer.String()})
+	return nil
+}
+
+func (co *contextObserver) Sync() error {
+	return nil
+}

--- a/internal/processorexecutor_test.go
+++ b/internal/processorexecutor_test.go
@@ -82,7 +82,7 @@ func Test_ObservedLogs(t *testing.T) {
 	executor.settings.Logger.Sugar().Debug("this is a log")
 	logEntries := executor.ObservedLogs().TakeAll()
 	assert.Len(t, logEntries, 1)
-	assert.Equal(t, "this is a log", logEntries[0].Message)
+	assert.Contains(t, logEntries[0].ConsoleEncodedEntry(), "this is a log")
 }
 
 func readTestData(t *testing.T, file string) string {

--- a/wasm/internal/ottlplayground.go
+++ b/wasm/internal/ottlplayground.go
@@ -6,14 +6,10 @@ import (
 	"fmt"
 	"strings"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/ottlplayground/internal"
 )
 
 var (
-	defaultLogEncoder         = zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
 	statementsExecutors       []internal.Executor
 	statementsExecutorsLookup = map[string]internal.Executor{}
 )
@@ -48,10 +44,7 @@ func takeObservedLogs(executor internal.Executor) string {
 	all := executor.ObservedLogs().TakeAll()
 	var s strings.Builder
 	for _, entry := range all {
-		v, err := defaultLogEncoder.EncodeEntry(entry.Entry, entry.Context)
-		if err == nil {
-			s.Write(v.Bytes())
-		}
+		s.WriteString(entry.ConsoleEncodedEntry())
 	}
 	return s.String()
 }

--- a/wasm/internal/ottlplayground_test.go
+++ b/wasm/internal/ottlplayground_test.go
@@ -7,12 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/ottlplayground/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/ottlplayground/internal"
 )
 
 func Test_NewErrorResult(t *testing.T) {
@@ -113,7 +111,7 @@ func Test_ExecuteStatements(t *testing.T) {
 		ottlDataPayload = "{}"
 	)
 
-	_, observedLogs := observer.New(zap.NewNop().Core())
+	_, observedLogs := internal.NewLogObserver(zap.NewNop().Core(), zap.NewDevelopmentEncoderConfig())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			executorName := tt.name
@@ -146,7 +144,7 @@ func Test_ExecuteStatements(t *testing.T) {
 
 func Test_TakeObserved_Logs(t *testing.T) {
 	mockExecutor := new(MockExecutor)
-	core, observedLogs := observer.New(zap.DebugLevel)
+	core, observedLogs := internal.NewLogObserver(zap.DebugLevel, zap.NewDevelopmentEncoderConfig())
 	mockExecutor.On("ObservedLogs").Return(observedLogs)
 
 	logger := zap.New(core)
@@ -178,9 +176,9 @@ func (m *MockExecutor) ExecuteMetricStatements(config, payload string) ([]byte, 
 	return []byte(args.String(0)), args.Error(1)
 }
 
-func (m *MockExecutor) ObservedLogs() *observer.ObservedLogs {
+func (m *MockExecutor) ObservedLogs() *internal.ObservedLogs {
 	args := m.Called()
-	return args.Get(0).(*observer.ObservedLogs)
+	return args.Get(0).(*internal.ObservedLogs)
 }
 
 func (m *MockExecutor) Metadata() internal.Metadata {

--- a/web/src/components/examples.js
+++ b/web/src/components/examples.js
@@ -38,7 +38,6 @@ const TRANSFORM_PROCESSOR_CONFIG_EXAMPLES = [
       'log_statements:\n' +
       ' - context: log\n' +
       '   statements:\n' +
-      '    # Use Concat function to combine any number of string, separated by a delimiter. \n' +
       '    - set(attributes["combined"], Concat([attributes["string.attribute"], attributes["boolean.attribute"]], " "))',
   },
   {


### PR DESCRIPTION
The `zaptest/observer` logger holds the `zapcore.Field` references in memory, and if the underlying object changes, it generates logs with duplicate field values. This PR adds a custom observer that only stores the LogEntry and the console-encoded entry value as string, witch is not affected by underlying field object changes.